### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -278,7 +278,8 @@ class GitUtils {
 
   async commitWithMessage(message: string): Promise<string> {
     try {
-      const result = await this.execAsync(`git commit -m "${message.replace(/"/g, '\\"')}"`);
+      const escapedMessage = message.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const result = await this.execAsync(`git commit -m "${escapedMessage}"`);
       return result.stdout;
     } catch (error) {
       throw new Error(`Commit error: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
Potential fix for [https://github.com/alexgutscher26/smart-committer/security/code-scanning/2](https://github.com/alexgutscher26/smart-committer/security/code-scanning/2)

The optimal fix is to avoid constructing a command string with interpolated variables altogether and instead use an API or method that takes arguments as a parameter array, which eliminates the need for manual shell escaping. However, since this code uses `execAsync` which passes the string to the shell, at a minimum the string should escape both backslashes and quotes in the right sequence, to ensure that e.g. `\"` is truly passed as a literal quote and not as escape for a backslash, and so on.

A better approach would use a library for argument quoting (such as `shell-quote`), but in this snippet, to minimize changes, the correct fix is to first escape all backslashes (`\` → `\\`), then all double-quotes (`"` → `\"`), as per standard shell escaping for double-quoted strings. This fix is local to line 281.

Therefore, edit line 281 in `src/index.ts`, updating the string such that backslashes are escaped first, followed by double quotes. No extra imports are needed unless you choose to use a quoting library (allowed per instructions).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
